### PR TITLE
DTV-18-BUG-Removing-a-game-from-the-filter-and-reopening-it-brings-ba…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doratv-test",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.3",

--- a/src/components/filter/Filter.tsx
+++ b/src/components/filter/Filter.tsx
@@ -14,6 +14,8 @@ import config from "../../config/config";
 import { IAutocompleteValue } from "../../interfaces/formInterfaces";
 import { sortArrayByString } from "../../utils/sort";
 import { GET } from "../../utils/constants";
+import useAxios from "../../customHooks/useAxios";
+import { ITwitchGameRequest } from "../../interfaces/liveInterfaces";
 
 const { TWITCH_API_BASE_URL } = config;
 
@@ -25,13 +27,16 @@ const Filter = () => {
     setActiveLanguage,
     fetchSearchResults,
     searchResults,
-    twitchGame,
-    fetchTwitchGame,
   } = useContext(TvContext);
   const [searchValue, setSearchValue] = useState<string>("");
   // TODO refactor filters and its interfaces
   const [autoCompleteValue, setAutoCompleteValue] = useState<any>("");
   const [appliedFilters, setAppliedFilters] = useState<any[]>([]);
+
+  const {
+    response: twitchGame,
+    fetchData: fetchTwitchGame,
+  }: ITwitchGameRequest = useAxios();
 
   const activeLanguageName = LANGUAGES.find(
     ({ code }) => code === activeLanguage
@@ -83,7 +88,7 @@ const Filter = () => {
   }, [searchValue]);
 
   useEffect(() => {
-    if (autoCompleteValue && fetchTwitchGame) {
+    if (autoCompleteValue) {
       fetchTwitchGame({
         baseUrl: TWITCH_API_BASE_URL,
         method: GET,

--- a/src/contexts/tvContext.tsx
+++ b/src/contexts/tvContext.tsx
@@ -8,7 +8,6 @@ import {
   IStream,
   IStreamsProps,
   ITvContext,
-  ITwitchGameRequest,
 } from "../interfaces/liveInterfaces";
 import { IGame } from "../interfaces/categoryInterfaces";
 
@@ -101,28 +100,11 @@ const TvContextProvider = ({ children }: { children: any }) => {
     fetchSearchResults,
   };
 
-  // Fetch game from Twitch
-
-  const {
-    response: twitchGame,
-    error: twitchGameError,
-    loading: twitchGameLoading,
-    fetchData: fetchTwitchGame,
-  }: ITwitchGameRequest = useAxios();
-
-  const twitchGameProps = {
-    twitchGame,
-    twitchGameError,
-    twitchGameLoading,
-    fetchTwitchGame,
-  };
-
   return (
     <TvContext.Provider
       value={{
         ...streamsProps,
         ...searchProps,
-        ...twitchGameProps,
       }}
     >
       {children}

--- a/src/interfaces/liveInterfaces.ts
+++ b/src/interfaces/liveInterfaces.ts
@@ -112,7 +112,4 @@ export interface ITwitchGameProps {
   fetchTwitchGame: ({ baseUrl, url, method, body, customHeaders }: any) => void;
 }
 
-export interface ITvContext
-  extends IStreamsProps,
-    ISearchCategoryProps,
-    ITwitchGameProps {}
+export interface ITvContext extends IStreamsProps, ISearchCategoryProps {}


### PR DESCRIPTION
- Fix a bug where removing a game from the filter, closing it and reopening it brought back the game filter automatically.
- Move the twitch game request to the filter component instead of the context.